### PR TITLE
Patch/validate survey response

### DIFF
--- a/README.md
+++ b/README.md
@@ -945,8 +945,8 @@ This is a successful response
 
 <details>
 <summary>  POST http://apollo-b-api.herokuapp.com/surveys/response - Answer a survey request </summary>
-Users that aren't owners of a topic cannot answer leader questions, but the owner of a topic can answer both leader and member questions
-Users that aren't members of a topic cannot answer questions from that topic
+Users that aren't owners of a topic cannot answer leader questions and topic owner cannot answer request questions
+Users that aren't members of a topic cannot answer request questions from that topic
 After submitting their answers, a user cannot add another answer or edit their existing answer
 
 ```JSON

--- a/README.md
+++ b/README.md
@@ -667,7 +667,7 @@ Example:
 </details>
 
 <details>
-     
+
 <summary>GET: http://apollo-b-api.herokuapp.com/surveys/survey/{id} Returns survey by id</summary>
 
 ```JSON
@@ -950,11 +950,11 @@ This is a successful response
 ```JSON
 [
     {
-        "questionId" : 12,
+        "questionid" : 12,
         "body" : "stuff"
     },
     { 
-       "questionId" : 13,
+       "questionid" : 13,
        "body" : "more stuff"
     }
 ]

--- a/README.md
+++ b/README.md
@@ -263,9 +263,9 @@ GET Endpoint
 
 <details>
 
-<summary>POST: http://appollo-b-api.herokuapp.com/topics/{joinCode} Current user joins a Topic.</summary>
+<summary>POST: http://appollo-b-api.herokuapp.com/topics/topic/{joinCode} Current user joins a Topic.</summary>
 
-Example: http://appollo-b-api.herokuapp.com/topics/lRQlkNGkg
+Example: http://appollo-b-api.herokuapp.com/topics/topic/lRQlkNGkg
 
 Returns 200 Success message
 
@@ -953,7 +953,7 @@ This is a successful response
         "questionid" : 12,
         "body" : "stuff"
     },
-    { 
+    {
        "questionid" : 13,
        "body" : "more stuff"
     }

--- a/README.md
+++ b/README.md
@@ -945,7 +945,9 @@ This is a successful response
 
 <details>
 <summary>  POST http://apollo-b-api.herokuapp.com/surveys/response - Answer a survey request </summary>
-
+Users that aren't owners of a topic cannot answer leader questions, but the owner of a topic can answer both leader and member questions
+Users that aren't members of a topic cannot answer questions from that topic
+After submitting their answers, a user cannot add another answer or edit their existing answer
 
 ```JSON
 [

--- a/src/main/java/com/lambdaschool/apollo/controllers/SurveyController.java
+++ b/src/main/java/com/lambdaschool/apollo/controllers/SurveyController.java
@@ -82,6 +82,11 @@ public class SurveyController {
         User user = userService.findByOKTAUserName(authentication.getName());
         for (QuestionBody qb: myList) {
             Question question = questionService.findById(qb.getQuestionid());
+            for (Answer a: question.getAnswers()) {
+                if (user.getUserid() == a.getUser().getUserid()) {
+                    throw new ResourceFoundException("Current user already answered question with id - " + question.getQuestionId());
+                }
+            }
             Survey survey = surveyService.findById(question.getSurvey().getSurveyid());
             Topic topic = topicService.findTopicById(survey.getTopic().getTopicId());
             List<TopicUsers> topicUsers = topic.getUsers();

--- a/src/main/java/com/lambdaschool/apollo/controllers/SurveyController.java
+++ b/src/main/java/com/lambdaschool/apollo/controllers/SurveyController.java
@@ -97,7 +97,9 @@ public class SurveyController {
                     throw new ResourceFoundException("Current user not owner of topic with id - " + topic.getTopicId());
                 }
             } else {
-                if ((!users.contains(user)) && (user.getUserid() != topic.getOwner().getUserid())) {
+                if (user.getUserid() == topic.getOwner().getUserid()) {
+                    throw new ResourceFoundException("Topic owner cannot answer request questions");
+                } else if (!users.contains(user)) {
                     throw new ResourceFoundException("Current user not a member of topic with id - " + topic.getTopicId());
                 }
             }

--- a/src/main/java/com/lambdaschool/apollo/controllers/SurveyController.java
+++ b/src/main/java/com/lambdaschool/apollo/controllers/SurveyController.java
@@ -2,13 +2,8 @@ package com.lambdaschool.apollo.controllers;
 
 import com.lambdaschool.apollo.exceptions.ResourceFoundException;
 import com.lambdaschool.apollo.handlers.HelperFunctions;
-import com.lambdaschool.apollo.models.Survey;
-import com.lambdaschool.apollo.models.Topic;
-import com.lambdaschool.apollo.models.User;
-import com.lambdaschool.apollo.services.AnswerService;
-import com.lambdaschool.apollo.services.SurveyService;
-import com.lambdaschool.apollo.services.TopicService;
-import com.lambdaschool.apollo.services.UserService;
+import com.lambdaschool.apollo.models.*;
+import com.lambdaschool.apollo.services.*;
 import com.lambdaschool.apollo.views.QuestionBody;
 import com.lambdaschool.apollo.views.SurveyQuestion;
 import io.swagger.annotations.Api;
@@ -27,6 +22,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.List;
 
 @RestController
@@ -48,6 +44,9 @@ public class SurveyController {
 
     @Autowired
     private TopicService topicService;
+
+    @Autowired
+    private QuestionService questionService;
 
     @ApiOperation(value = "Create new survey ")
     @ApiResponses(value = {
@@ -80,9 +79,25 @@ public class SurveyController {
             @Valid
             @RequestBody List<QuestionBody> myList)
             throws URISyntaxException {
-
-        answerService.save(myList, userService.findByOKTAUserName(authentication.getName()));
-
+        User user = userService.findByOKTAUserName(authentication.getName());
+        for (QuestionBody qb: myList) {
+            Question question = questionService.findById(qb.getQuestionid());
+            Survey survey = surveyService.findById(question.getSurvey().getSurveyid());
+            Topic topic = topicService.findTopicById(survey.getTopic().getTopicId());
+            List<TopicUsers> topicUsers = topic.getUsers();
+            List<User> users = new ArrayList<>();
+            for (TopicUsers tu: topicUsers) users.add(tu.getUser());
+            if (question.isLeader()) {
+                if (user.getUserid() != topic.getOwner().getUserid()) {
+                    throw new ResourceFoundException("Current user not owner of topic with id - " + topic.getTopicId());
+                }
+            } else {
+                if ((!users.contains(user)) && (user.getUserid() != topic.getOwner().getUserid())) {
+                    throw new ResourceFoundException("Current user not a member of topic with id - " + topic.getTopicId());
+                }
+            }
+            answerService.save(qb, user);
+        }
         return new ResponseEntity<>(null, HttpStatus.CREATED);
     }
 

--- a/src/main/java/com/lambdaschool/apollo/services/AnswerService.java
+++ b/src/main/java/com/lambdaschool/apollo/services/AnswerService.java
@@ -12,7 +12,7 @@ public interface AnswerService {
 
     void delete(long id);
 
-    void save(List<QuestionBody> l, User user);
+    void save(QuestionBody qb, User user);
 
     Answer update(Answer answer);
 

--- a/src/main/java/com/lambdaschool/apollo/services/AnswerServiceImpl.java
+++ b/src/main/java/com/lambdaschool/apollo/services/AnswerServiceImpl.java
@@ -73,34 +73,6 @@ public class AnswerServiceImpl implements AnswerService {
 
         answerRepository.save(newAnswer);
 
-        // for (QuestionBody qb : qbList) {
-        //     Answer newAnswer = new Answer();
-        //     if (qb.getBody() != null) {
-        //         newAnswer.setBody(qb.getBody());
-        //     } else {
-        //         throw new ResourceNotFoundException("Answer has no body!");
-        //     }
-        //     Question question = questionService.findById(qb.getQuestionid());
-        //     if (question != null) {
-        //         newAnswer.setQuestion(question);
-        //     } else {
-        //         throw new ResourceNotFoundException("Question Id " + qb.getQuestionid() + " Not Found");
-        //     }
-        //     if (user == userService.findUserById(user.getUserid())) {
-        //         newAnswer.setUser(user);
-        //     } else {
-        //         throw new ResourceNotFoundException("User Id " + user.getUserid() + " Not Found");
-        //     }
-        //     Survey survey = question.getSurvey();
-        //     if (survey != null) {
-        //         newAnswer.setSurvey(survey);
-        //     } else {
-        //         throw new ResourceNotFoundException("Survey Id " + question.getSurvey().getSurveyId() + "Nor Found");
-        //     }
-        //
-        //     answerRepository.save(newAnswer);
-        // }
-
 //        yes this is dead code but it will get implemented in an future save method overload
 //        if (answer.getAnswerId() != 0) {
 //            Answer oldAnswer = answerRepository.findById(answer.getAnswerId())

--- a/src/main/java/com/lambdaschool/apollo/services/AnswerServiceImpl.java
+++ b/src/main/java/com/lambdaschool/apollo/services/AnswerServiceImpl.java
@@ -45,35 +45,61 @@ public class AnswerServiceImpl implements AnswerService {
 
     @Transactional
     @Override
-    public void save(List<QuestionBody> qbList, User user) {
+    public void save(QuestionBody qb, User user) {
 
-        for (QuestionBody qb : qbList) {
-            Answer newAnswer = new Answer();
-            if (qb.getBody() != null) {
-                newAnswer.setBody(qb.getBody());
-            } else {
-                throw new ResourceNotFoundException("Answer has no body!");
-            }
-            Question question = questionService.findById(qb.getQuestionid());
-            if (question != null) {
-                newAnswer.setQuestion(question);
-            } else {
-                throw new ResourceNotFoundException("Question Id " + qb.getQuestionid() + " Not Found");
-            }
-            if (user == userService.findUserById(user.getUserid())) {
-                newAnswer.setUser(user);
-            } else {
-                throw new ResourceNotFoundException("User Id " + user.getUserid() + " Not Found");
-            }
-            Survey survey = question.getSurvey();
-            if (survey != null) {
-                newAnswer.setSurvey(survey);
-            } else {
-                throw new ResourceNotFoundException("Survey Id " + question.getSurvey().getSurveyId() + "Nor Found");
-            }
-
-            answerRepository.save(newAnswer);
+        Answer newAnswer = new Answer();
+        if (qb.getBody() != null) {
+            newAnswer.setBody(qb.getBody());
+        } else {
+            throw new ResourceNotFoundException("Answer has no body!");
         }
+        Question question = questionService.findById(qb.getQuestionid());
+        if (question != null) {
+            newAnswer.setQuestion(question);
+        } else {
+            throw new ResourceNotFoundException("Question Id " + qb.getQuestionid() + " Not Found");
+        }
+        if (user == userService.findUserById(user.getUserid())) {
+            newAnswer.setUser(user);
+        } else {
+            throw new ResourceNotFoundException("User Id " + user.getUserid() + " Not Found");
+        }
+        Survey survey = question.getSurvey();
+        if (survey != null) {
+            newAnswer.setSurvey(survey);
+        } else {
+            throw new ResourceNotFoundException("Survey Id " + question.getSurvey().getSurveyId() + "Not Found");
+        }
+
+        answerRepository.save(newAnswer);
+
+        // for (QuestionBody qb : qbList) {
+        //     Answer newAnswer = new Answer();
+        //     if (qb.getBody() != null) {
+        //         newAnswer.setBody(qb.getBody());
+        //     } else {
+        //         throw new ResourceNotFoundException("Answer has no body!");
+        //     }
+        //     Question question = questionService.findById(qb.getQuestionid());
+        //     if (question != null) {
+        //         newAnswer.setQuestion(question);
+        //     } else {
+        //         throw new ResourceNotFoundException("Question Id " + qb.getQuestionid() + " Not Found");
+        //     }
+        //     if (user == userService.findUserById(user.getUserid())) {
+        //         newAnswer.setUser(user);
+        //     } else {
+        //         throw new ResourceNotFoundException("User Id " + user.getUserid() + " Not Found");
+        //     }
+        //     Survey survey = question.getSurvey();
+        //     if (survey != null) {
+        //         newAnswer.setSurvey(survey);
+        //     } else {
+        //         throw new ResourceNotFoundException("Survey Id " + question.getSurvey().getSurveyId() + "Nor Found");
+        //     }
+        //
+        //     answerRepository.save(newAnswer);
+        // }
 
 //        yes this is dead code but it will get implemented in an future save method overload
 //        if (answer.getAnswerId() != 0) {


### PR DESCRIPTION
Added validation for user survey responses relating to the "/surveys/response" post request. Only owners of a topic can answer leader questions, but they can also answer member questions. Only members of a topic can answer questions from that topic. After a user has submitted their answers they can't change their original answer or add another answer to that question.

## Before making the Pull Request:

- [x] Is there a description to this pull request that points to a specific user story, feature, or bugfix?
- [x] Are there comments where the code may be unclear?
- [x] Is all dead code, commented out code, etc. removed?
- [ ] Are there tests written for these changes?
- [x] Does the ReadMe need to be updated?


## Before being merged by the TPL:

- [x] Has the pull request been reviewed by at least two team members? 
- [x] Did they leave any comments or suggestions? 
- [x] Were those suggestions acted on?
- [x] Are all tests passing?
- [x] Has the documentation been updated?
