### PR TITLE
Bugfix/responded

### DIFF
--- a/src/main/java/com/lambdaschool/apollo/controllers/TopicController.java
+++ b/src/main/java/com/lambdaschool/apollo/controllers/TopicController.java
@@ -1,5 +1,7 @@
 package com.lambdaschool.apollo.controllers;
 
+import com.lambdaschool.apollo.handlers.HelperFunctions;
+import com.lambdaschool.apollo.models.Survey;
 import com.lambdaschool.apollo.models.Topic;
 import com.lambdaschool.apollo.models.User;
 import com.lambdaschool.apollo.services.TopicService;
@@ -30,6 +32,9 @@ public class TopicController {
     @Autowired
     private UserService userService;
 
+    @Autowired
+    private HelperFunctions helperFunctions;
+
     @ApiOperation(value = "Get all topics of current user ")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Successfully retrieved list", response = Topic.class, responseContainer = "List"),
@@ -42,6 +47,13 @@ public class TopicController {
     public ResponseEntity<?> listUserTopics(Authentication authentication) {
         List<Topic> myTopics = new ArrayList<>();
         myTopics = topicService.findTopicsByUser(authentication.getName());
+        List<Survey> surveyRequests = new ArrayList<>();
+        myTopics.iterator().forEachRemaining(topic -> {
+            surveyRequests.addAll(topic.getSurveysrequests());
+        });
+        for (Survey surveyRequest : surveyRequests) {
+            helperFunctions.hasResponded(surveyRequest, userService.findByOKTAUserName(authentication.getName()));
+        }
         return new ResponseEntity<>(myTopics, HttpStatus.OK);
     }
 

--- a/src/main/java/com/lambdaschool/apollo/handlers/HelperFunctions.java
+++ b/src/main/java/com/lambdaschool/apollo/handlers/HelperFunctions.java
@@ -103,10 +103,11 @@ public class HelperFunctions {
         questions = questionService.findAllBySurveyId(survey.getSurveyId());
 
         for (Question q : questions) {
-            for (Answer a : q.getAnswers()) {
-                if (a.getUser() == user) {
-                    survey.setHasResponded(true);
-                }
+            if (answerService.findByQuestionIdAndUserId(q.getQuestionId(), user.getUserid()) != null) {
+                survey.setHasResponded(true);
+                break;
+            } else {
+                continue;
             }
         }
     }

--- a/src/main/java/com/lambdaschool/apollo/repository/AnswerRepository.java
+++ b/src/main/java/com/lambdaschool/apollo/repository/AnswerRepository.java
@@ -1,6 +1,7 @@
 package com.lambdaschool.apollo.repository;
 
 import com.lambdaschool.apollo.models.Answer;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
 import java.util.List;
@@ -8,4 +9,7 @@ import java.util.List;
 public interface AnswerRepository extends CrudRepository<Answer, Long> {
 
     List<Answer> findBySurvey_surveyid(long surveyid);
+
+    @Query(value = "SELECT * FROM Answers WHERE questionid = :questionid AND userid = :userid", nativeQuery = true)
+    Answer findAnswerByQuestionIdAndUserId(long questionid, long userid);
 }

--- a/src/main/java/com/lambdaschool/apollo/services/AnswerService.java
+++ b/src/main/java/com/lambdaschool/apollo/services/AnswerService.java
@@ -19,4 +19,6 @@ public interface AnswerService {
     List<Answer> findAllAnswers();
 
     List<Answer> findBySurveyId(long surveyid);
+
+    Answer findByQuestionIdAndUserId(long questionId, long userId);
 }

--- a/src/main/java/com/lambdaschool/apollo/services/AnswerServiceImpl.java
+++ b/src/main/java/com/lambdaschool/apollo/services/AnswerServiceImpl.java
@@ -101,4 +101,14 @@ public class AnswerServiceImpl implements AnswerService {
         List<Answer> answers = answerRepository.findBySurvey_surveyid(surveyid);
         return answers;
     }
+
+    @Override
+    public Answer findByQuestionIdAndUserId(long questionId, long userId) {
+        Answer answer = answerRepository.findAnswerByQuestionIdAndUserId(questionId, userId);
+        if (answer == null) {
+            return null;
+        } else {
+            return answer;
+        }
+    }
 }


### PR DESCRIPTION
1. fix hasResponded bug of returning wrong values.
***Note***
Currently, only **3** endpoints have to ability to determine if the user has responded to the survey request or not.
 - GET: http://apollo-b-api.herokuapp.com/topics/topics - Get all topics for a user
 - GET: http://apollo-b-api.herokuapp.com/surveys/all Returns list of surveys
 - GET: http://apollo-b-api.herokuapp.com/surveys/survey/{id} Returns survey by id

## Before making the Pull Request:

- [x] Is there a description to this pull request that points to a specific user story, feature, or bugfix?
- [x] Are there comments where the code may be unclear?
- [ ] Is all dead code, commented out code, etc. removed?
- [ ] Are there tests written for these changes?
- [ ] Does the ReadMe need to be updated?


## Before being merged by the TPL:

- [x] Has the pull request been reviewed by at least two team members? 
- [x] Did they leave any comments or suggestions? 
- [ ] Were those suggestions acted on?
- [x] Are all tests passing?
- [ ] Has the documentation been updated?
